### PR TITLE
A few fixes

### DIFF
--- a/src/MessageInterface.hhi
+++ b/src/MessageInterface.hhi
@@ -38,7 +38,7 @@ interface MessageInterface
      * @param string $version HTTP protocol version
      * @return self
      */
-    public function withProtocolVersion(string $version): MessageInterface;
+    public function withProtocolVersion(string $version): this;
 
     /**
      * Retrieves all message header values.
@@ -129,7 +129,7 @@ interface MessageInterface
      * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader(string $name, mixed $value): MessageInterface;
+    public function withHeader(string $name, mixed $value): this;
 
     /**
      * Return an instance with the specified header appended with the given value.
@@ -147,7 +147,7 @@ interface MessageInterface
      * @return self
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader(string $name, mixed $value): MessageInterface;
+    public function withAddedHeader(string $name, mixed $value): this;
 
     /**
      * Return an instance without the specified header.
@@ -161,7 +161,7 @@ interface MessageInterface
      * @param string $name Case-insensitive header field name to remove.
      * @return self
      */
-    public function withoutHeader(string $name): MessageInterface;
+    public function withoutHeader(string $name): this;
 
     /**
      * Gets the body of the message.
@@ -183,5 +183,5 @@ interface MessageInterface
      * @return self
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamInterface $body): MessageInterface;
+    public function withBody(StreamInterface $body): this;
 }

--- a/src/RequestInterface.hhi
+++ b/src/RequestInterface.hhi
@@ -58,7 +58,7 @@ interface RequestInterface extends MessageInterface
      * @param mixed $requestTarget
      * @return self
      */
-    public function withRequestTarget(mixed $requestTarget): RequestInterface;
+    public function withRequestTarget(mixed $requestTarget): this;
 
     /**
      * Retrieves the HTTP method of the request.
@@ -82,7 +82,7 @@ interface RequestInterface extends MessageInterface
      * @return self
      * @throws \InvalidArgumentException for invalid HTTP methods.
      */
-    public function withMethod(string $method): RequestInterface;
+    public function withMethod(string $method): this;
 
     /**
      * Retrieves the URI instance.
@@ -125,5 +125,5 @@ interface RequestInterface extends MessageInterface
      * @param bool $preserveHost Preserve the original state of the Host header.
      * @return self
      */
-    public function withUri(UriInterface $uri, bool $preserveHost = false): RequestInterface;
+    public function withUri(UriInterface $uri, bool $preserveHost = false): this;
 }

--- a/src/ResponseInterface.hhi
+++ b/src/ResponseInterface.hhi
@@ -49,7 +49,7 @@ interface ResponseInterface extends MessageInterface
      * @return self
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface;
+    public function withStatus(int $code, string $reasonPhrase = ''): this;
 
     /**
      * Gets the response reason phrase associated with the status code.

--- a/src/ServerRequestInterface.hhi
+++ b/src/ServerRequestInterface.hhi
@@ -84,7 +84,7 @@ interface ServerRequestInterface extends RequestInterface
      * @param array $cookies Array of key/value pairs representing cookies.
      * @return self
      */
-    public function withCookieParams(array<string,string> $cookies): ServerRequestInterface;
+    public function withCookieParams(array<string,string> $cookies): this;
 
     /**
      * Retrieve query string arguments.
@@ -122,7 +122,7 @@ interface ServerRequestInterface extends RequestInterface
      *     $_GET.
      * @return self
      */
-    public function withQueryParams(array<string,string> $query): ServerRequestInterface;
+    public function withQueryParams(array<string,string> $query): this;
 
     /**
      * Retrieve normalized file upload data.
@@ -149,7 +149,7 @@ interface ServerRequestInterface extends RequestInterface
      * @return self
      * @throws \InvalidArgumentException if an invalid structure is provided.
      */
-    public function withUploadedFiles(array $uploadedFiles): ServerRequestInterface;
+    public function withUploadedFiles(array $uploadedFiles): this;
 
     /**
      * Retrieve any parameters provided in the request body.
@@ -196,7 +196,7 @@ interface ServerRequestInterface extends RequestInterface
      * @throws \InvalidArgumentException if an unsupported argument type is
      *     provided.
      */
-    public function withParsedBody(mixed $data): ServerRequestInterface;
+    public function withParsedBody(mixed $data): this;
 
     /**
      * Retrieve attributes derived from the request.
@@ -243,7 +243,7 @@ interface ServerRequestInterface extends RequestInterface
      * @param mixed $value The value of the attribute.
      * @return self
      */
-    public function withAttribute(string $name, mixed $value): ServerRequestInterface;
+    public function withAttribute(string $name, mixed $value): this;
 
     /**
      * Return an instance that removes the specified derived request attribute.
@@ -259,5 +259,5 @@ interface ServerRequestInterface extends RequestInterface
      * @param string $name The attribute name.
      * @return self
      */
-    public function withoutAttribute(string $name): ServerRequestInterface;
+    public function withoutAttribute(string $name): this;
 }


### PR DESCRIPTION
First, I moved `ResponseInterface.hh` to `ResponseInterface.hhi`.

Second, I changed all of the fluent methods to return `this` instead of their own class name.

In this example:

``` hack
public function addHeader(ResponseInterface $response) : ResponseInterface
    return $response->withHeader('foo', 'bar');
}
```

…the type checker would have barfed about `MessageInterface` not being compatible with `ResponseInterface`. By changing all the return type annotations to `this`, the type checker behaves as expected, and it's in line with the PSR-7 standard because the doc comments already have `@return self` in them.
